### PR TITLE
[FIX] RCE using execFile()

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var chokidar = require('chokidar');
 var glob = require('glob');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var defaults = require('./defaults');
 var root = process.cwd();
 
@@ -97,7 +97,7 @@ function Mojo(emitter, config, executor, logger) {
   }
 
   function grep(callback) {
-    exec('egrep -rl "describe\\([\'\\"].*' + config.grep + '" ' + config.grepDir, {
+    execFile('egrep', ['-rl', 'describe\\([\'\\"].*' + config.grep + ' ' + config.grepDir], {
       cwd: root
     }, function(error, stdout) {
       if (!error) {


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-karma-mojo

### ⚙️ Description *

The `karma-mojo` module was vulnerable against `arbitrary command injection` since `user supplied` inputs were unsafely handled and concatenated inside a command which was then executed.

### 💻 Technical Description *

I used the `execFile` function instead of `exec` in order to avoid further `command injection` issues :smile:

### 🐛 Proof of Concept (PoC) *

```js
var root = require("karma-mojo");
var config = {
   runnerPath: './karma.log',
  grep: "\"& touch Song\"",
  grepDir:"",
  length: 1
}
root['reporter:mojo'][1]('',config, '', {'create': function(){}});
```

![Screenshot from 2020-09-04 14-51-45](https://user-images.githubusercontent.com/33063403/92243081-27ad7780-eec1-11ea-97dd-cef8c4c92ee7.png)

### 🔥 Proof of Fix (PoF) *

Use the fixed version with the same PoC

![Screenshot from 2020-09-04 15-11-24](https://user-images.githubusercontent.com/33063403/92243106-3136df80-eec1-11ea-86dc-8474bebf7ef1.png)

### 👍 User Acceptance Testing (UAT)

The issue doesn't persist and the command retrieves perfectly :smile: